### PR TITLE
Line graph hover

### DIFF
--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -17,6 +17,7 @@ const propTypes = {
   xAxisLabel: PropTypes.string,
   yAxisLabel: PropTypes.string,
   onHover: PropTypes.func,
+  onMouseOut: PropTypes.func,
   emptyText: PropTypes.string,
   isUTC: PropTypes.bool,
 };
@@ -40,6 +41,7 @@ const defaultProps = {
   xAxisLabel: 'X Axis',
   yAxisLabel: 'Y Axis',
   onHover: () => {},
+  onMouseOut: () => {},
   emptyText: 'There is currently no data available for the parameters selected. Please try a different combination.',
   isUTC: false,
 };
@@ -274,7 +276,14 @@ class LineGraph extends Component {
       .style('pointer-events', 'all')
       .on('mousemove', () => {
         this.onMouseMove();
+      })
+      .on('mouseout', () => {
+        this.onMouseOut();
       });
+  }
+
+  onMouseOut() {
+    this.props.onMouseOut();
   }
 
   onMouseMove() {
@@ -294,7 +303,15 @@ class LineGraph extends Component {
       d = timestamp - d0[1] > d1[1] - timestamp ? d1 : d0;
     }
 
-    this.props.onHover(d, d3.event.pageX, d3.event.pageY);
+    const mouseData = {
+      data: d,
+      pageX: d3.event.pageX,
+      pageY: d3.event.pageY,
+      graphX: this.x(d[1]),
+      graphY: this.y(d[0]),
+    };
+
+    this.props.onHover(mouseData);
   }
 
   render() {

--- a/components/LineGraph/LineGraph.story.js
+++ b/components/LineGraph/LineGraph.story.js
@@ -91,6 +91,7 @@ storiesOf('LineGraph', module)
         [53.733333333333, 1507564800000],
       ]}
       onHover={action('Hover')}
+      onMouseOut={action('Mouseout')}
     />
   ))
   .addWithInfo('Empty', ` Empty Example. `, () => (

--- a/components/LineGraph/LineGraph.story.js
+++ b/components/LineGraph/LineGraph.story.js
@@ -87,9 +87,10 @@ storiesOf('LineGraph', module)
     <LineGraph
       data={[
         [48.633333333333, 1507563000000],
-        [49.933333333333, 1507563900000],
+        [12, 1507563900000],
         [53.733333333333, 1507564800000],
       ]}
+      onHover={action('Hover')}
     />
   ))
   .addWithInfo('Empty', ` Empty Example. `, () => (


### PR DESCRIPTION
Switched around the `onHover` function to return an object of data.

Added a onMouseOut function to invoke a tooltip toggle