### PR TITLE
fix(line-graph): onMouseOut function throws error

### DIFF
--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -311,7 +311,7 @@ class LineGraph extends Component {
   }
 
   onMouseOut() {
-    if (data.length > 2) {
+    if (this.props.data.length > 2) {
       this.props.onMouseOut();
     }
   }


### PR DESCRIPTION
MouseOut function throws an error because `data` variable is not defined, should be `this.props.data`

line 313
```
  onMouseOut() {
    if (data.length > 2) {
      this.props.onMouseOut();
    }
  }
```