### PR TITLE
fix(build): make package runnable on other babel projects

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
     "stage-1"
   ],
   "plugins": [
+    "transform-runtime",
     "transform-object-assign"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@storybook/react": "^3.1.6",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "bluebird": "^3.5.0",
     "carbon-components": "^7.13.2",
     "carbon-components-react": "^3.4.6",


### PR DESCRIPTION
there can only be one babel-polyfill, packages should use `transform-runtime` plugin to ensure that there is no duplicate:

https://babeljs.io/docs/plugins/transform-runtime