### PR TITLE
LineGraph.onHover() should return graph values for multiple lines

### DIFF
--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -346,7 +346,6 @@ class LineGraph extends Component {
         d = timestamp - d0[d0.length - 1] > d1[d1.length - 1] - timestamp
           ? d1
           : d0;
-        const graphYArray = d.slice(0, -1).map(el => this.y(el));
 
         mouseData = {
           data: d,
@@ -354,7 +353,7 @@ class LineGraph extends Component {
           pageY: d3.event.pageY,
           graphX: this.x(d[d.length - 1]),
           graphY: this.y(d[0]),
-          graphYArray
+          graphYArray: d.slice(0, -1).map(el => this.y(el)),
         };
       }
 

--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -353,7 +353,7 @@ class LineGraph extends Component {
           pageY: d3.event.pageY,
           graphX: this.x(d[d.length - 1]),
           graphY: this.y(d[0]),
-          graphYArray: d.slice(0, -1).map(el => this.y(el)),
+          graphYArray: d.slice(0, -1).map(this.y),
         };
       }
 

--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -346,7 +346,7 @@ class LineGraph extends Component {
         d = timestamp - d0[d0.length - 1] > d1[d1.length - 1] - timestamp
           ? d1
           : d0;
-        const graphYArray = d.map(el => this.y(el)).slice(0, -1);
+        const graphYArray = d.slice(0, -1).map(el => this.y(el));
 
         mouseData = {
           data: d,

--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -102,7 +102,7 @@ class LineGraph extends Component {
       this.updateData(nextProps);
     }
   }
-  
+
   shouldComponentUpdate(nextProps) {
     return this.props.data !== nextProps.data;
   }
@@ -346,6 +346,7 @@ class LineGraph extends Component {
         d = timestamp - d0[d0.length - 1] > d1[d1.length - 1] - timestamp
           ? d1
           : d0;
+        const graphYArray = d.map(el => this.y(el)).slice(0, -1);
 
         mouseData = {
           data: d,
@@ -353,6 +354,7 @@ class LineGraph extends Component {
           pageY: d3.event.pageY,
           graphX: this.x(d[d.length - 1]),
           graphY: this.y(d[0]),
+          graphYArray
         };
       }
 


### PR DESCRIPTION
The `LineGraph` component can already render multiple lines of data, and the `onHover` event will return the _value_ of multiple lines near the cursor. 

However, the `onHover` event only includes the x and y _location_ of the first graph line entered. If the user needs the screen location of the other lines, he or she is out of luck.

This simple, one-line solution adds the additional data without breaking the api for existing users.
