### PR TITLE
Grouped bar chart

### DIFF
--- a/components/BarGraph/BarGraph.story.js
+++ b/components/BarGraph/BarGraph.story.js
@@ -9,14 +9,33 @@ function createData(num) {
     let d = new Date();
     let randomNum = Math.floor(Math.random() * 1000 + 1);
     d = d.setDate(d.getDate() - i * 30);
-    tempArr.push(randomNum, d);
+    tempArr.push([randomNum], d);
     data.push(tempArr);
   }
-
   return data;
 }
 
-let data = createData(12).sort(function(a, b) {
+function createGroupedData(num) {
+  let data = [];
+  for (let i = 0; i < num; i++) {
+    let numArr = [];
+    const one = Math.floor(Math.random() * 1000 + 10);
+    const two = Math.floor(Math.random() * 1000 + 10);
+    const three = Math.floor(Math.random() * 1000 + 10);
+    const four = Math.floor(Math.random() * 1000 + 10);
+    numArr.push(one, two, three, four);
+    let d = i;
+    const entry = [numArr, d];
+    data.push(entry);
+  }
+  return data;
+}
+
+let data = createData(20).sort(function(a, b) {
+  return a[1] - b[1];
+});
+
+let groupedData = createGroupedData(1).sort(function(a, b) {
   return a[1] - b[1];
 });
 
@@ -35,16 +54,23 @@ const props = {
   timeFormat: '%b',
   yAxisLabel: 'Amount ($)',
   xAxisLabel: 'Date',
-  data: data,
   onHover: action('Hover'),
   id: 'bar-graph-1',
   containerId: 'bar-graph-container',
 };
 
-storiesOf('BarGraph', module).addWithInfo(
-  'Default',
-  `
+storiesOf('BarGraph', module)
+  .addWithInfo(
+    'Default',
+    `
       Bar Graph.
     `,
-  () => <BarGraph onHover={action('Hover')} {...props} />
-);
+    () => <BarGraph onHover={action('Hover')} data={data} {...props} />
+  )
+  .addWithInfo(
+    'Grouped',
+    `
+     Grouped Bar Graph.
+    `,
+    () => <BarGraph onHover={action('Hover')} data={groupedData} {...props} />
+  );

--- a/components/BarGraph/BarGraph.story.js
+++ b/components/BarGraph/BarGraph.story.js
@@ -1,15 +1,82 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { storiesOf, action } from '@storybook/react';
 import BarGraph from './BarGraph';
+
+class UpdatingBarGraphContainer extends Component {
+  state = {
+    data: this.createGroupedData(6).sort(function(a, b) {
+      return a[a.length - 1] - b[b.length - 1];
+    }),
+  };
+
+  componentDidMount() {
+    let i = 0;
+    setInterval(() => {
+      this.updateData(i);
+      i++;
+    }, 5000);
+  }
+
+  createGroupedData(num) {
+    let data = [];
+    for (let i = 0; i < num; i++) {
+      let numArr = [];
+      const one = Math.floor(Math.random() * 1000 + 10);
+      const two = Math.floor(Math.random() * 1000 + 10);
+      const three = Math.floor(Math.random() * 1000 + 10);
+      const four = Math.floor(Math.random() * 1000 + 10);
+      numArr.push(one, two, three, four);
+      let d = i;
+      const entry = [numArr, d];
+      data.push(entry);
+    }
+    return data;
+  }
+
+  updateData(i) {
+    let data = this.createGroupedData(6).sort(function(a, b) {
+      return a[a.length - 1] - b[b.length - 1];
+    });
+
+    this.setState({
+      data,
+      xAxisLabel: `${i}`,
+      yAxisLabel: `${i}`,
+    });
+  }
+
+  render() {
+    const { data } = this.state;
+    const props = {
+      margin: {
+        top: 30,
+        right: 20,
+        bottom: 75,
+        left: 65,
+      },
+      height: 300,
+      width: 800,
+      labelOffsetY: 55,
+      labelOffsetX: 65,
+      axisOffset: 16,
+      yAxisLabel: this.state.yAxisLabel,
+      xAxisLabel: this.state.xAxisLabel,
+      onHover: action('Hover'),
+      id: this.props.id,
+      containerId: this.props.containerId,
+      drawLine: this.props.drawLine,
+    };
+
+    return <BarGraph data={data} {...props} />;
+  }
+}
 
 function createData(num) {
   let data = [];
   for (let i = 0; i < num; i++) {
     let tempArr = [];
-    let d = new Date();
     let randomNum = Math.floor(Math.random() * 1000 + 1);
-    d = d.setDate(d.getDate() - i * 30);
-    tempArr.push([randomNum], d);
+    tempArr.push([randomNum], i);
     data.push(tempArr);
   }
   return data;
@@ -24,18 +91,23 @@ function createGroupedData(num) {
     const three = Math.floor(Math.random() * 1000 + 10);
     const four = Math.floor(Math.random() * 1000 + 10);
     numArr.push(one, two, three, four);
-    let d = i;
+    let d = new Date();
+    d = d.setDate(d.getDate() - i * 30);
     const entry = [numArr, d];
     data.push(entry);
   }
   return data;
 }
 
-let data = createData(20).sort(function(a, b) {
+let data = createData(12).sort(function(a, b) {
   return a[1] - b[1];
 });
 
-let groupedData = createGroupedData(1).sort(function(a, b) {
+let groupedData = createGroupedData(4).sort(function(a, b) {
+  return a[1] - b[1];
+});
+
+let singleData = createData(1).sort(function(a, b) {
   return a[1] - b[1];
 });
 
@@ -51,7 +123,6 @@ const props = {
   labelOffsetY: 55,
   labelOffsetX: 65,
   axisOffset: 16,
-  timeFormat: '%b',
   yAxisLabel: 'Amount ($)',
   xAxisLabel: 'Date',
   onHover: action('Hover'),
@@ -72,5 +143,26 @@ storiesOf('BarGraph', module)
     `
      Grouped Bar Graph.
     `,
-    () => <BarGraph onHover={action('Hover')} data={groupedData} {...props} />
+    () => (
+      <BarGraph
+        timeFormat="%b"
+        onHover={action('Hover')}
+        data={groupedData}
+        {...props}
+      />
+    )
+  )
+  .addWithInfo(
+    'Updating',
+    `
+     Updating Grouped Bar Graph.
+    `,
+    () => <UpdatingBarGraphContainer />
+  )
+  .addWithInfo(
+    'Empty',
+    `
+     Empty Bar Graph.
+    `,
+    () => <BarGraph onHover={action('Hover')} data={singleData} {...props} />
   );


### PR DESCRIPTION
Adds in functionality for grouped data.


For Grouped arrays, expected data will be in the following example format:

```
[
  [[100, 150, 200], 'Group One'], 
  [[200, 250, 300], 'Group Two']
]
```

While simple, non-grouped `BarGraphs`  will be in the following format: 

```
[
  [100, 'December'], 
  [200, 'January']
]
```