### PR TITLE
Data tooltip

### DIFF
--- a/.storybook/_container.scss
+++ b/.storybook/_container.scss
@@ -1,7 +1,7 @@
 $css--font-face: true;
 
 @import '~carbon-components/scss/globals/scss/styles.scss';
-@import '../index.scss';
+@import '../index';
 
 body {
   padding: 1rem 3%;

--- a/components/BarGraph/BarGraph.js
+++ b/components/BarGraph/BarGraph.js
@@ -202,11 +202,13 @@ class BarGraph extends Component {
           .selectAll('rect')
           .data(d => {
             this.count++;
+            let itemLabel = d[1];
             return d[0].map((key, index) => {
               return {
                 key,
                 index,
                 group: this.count - 1,
+                itemLabel,
               };
             });
           })
@@ -246,8 +248,8 @@ class BarGraph extends Component {
 
       barContainer
         .selectAll('rect')
-        .on('mouseover', d => this.onMouseEnter(d))
-        .on('mouseout', d => this.onMouseOut(d));
+        .on('mouseover', (d, i) => this.onMouseEnter(d, i))
+        .on('mouseout', (d, i) => this.onMouseOut(d, i));
     }
   }
 
@@ -279,37 +281,47 @@ class BarGraph extends Component {
       .attr('text-anchor', 'middle');
   }
 
-  getMouseData(d) {
+  getMouseData(d, i) {
     let mouseData;
+
     if (d.key) {
       mouseData = {
-        data: d.key,
+        data: [d.key],
         index: d.index,
         group: d.group,
+        label: d.itemLabel,
       };
     } else {
       mouseData = {
-        data: d[0][0] || d[0],
-        index: d[1],
+        data: [d[0][0]] || [d[0]],
+        index: i,
         group: 0,
+        label: d[1],
       };
     }
 
     return mouseData;
   }
 
-  onMouseEnter(d) {
-    const mouseData = this.getMouseData(d);
+  onMouseEnter(d, i) {
+    const { timeFormat } = this.props;
+    const mouseData = this.getMouseData(d, i);
 
     let rect = this.svg.select(
       `rect[data-bar="${mouseData.index}-${mouseData.group}"]`
     );
     rect.attr('fill', d3.color(rect.attr('fill')).darker());
+
+    if (timeFormat) {
+      const format = d3.timeFormat(timeFormat);
+
+      mouseData.label = format(mouseData.label);
+    }
     this.props.onHover(mouseData);
   }
 
-  onMouseOut(d) {
-    const mouseData = this.getMouseData(d);
+  onMouseOut(d, i) {
+    const mouseData = this.getMouseData(d, i);
 
     let rect = this.svg.select(
       `rect[data-bar="${mouseData.index}-${mouseData.group}"]`

--- a/components/BarGraph/BarGraph.story.js
+++ b/components/BarGraph/BarGraph.story.js
@@ -76,7 +76,9 @@ function createData(num) {
   for (let i = 0; i < num; i++) {
     let tempArr = [];
     let randomNum = Math.floor(Math.random() * 1000 + 1);
-    tempArr.push([randomNum], i);
+    let d = new Date();
+    d = d.setDate(d.getDate() + i * 30);
+    tempArr.push([randomNum], d);
     data.push(tempArr);
   }
   return data;
@@ -137,7 +139,14 @@ storiesOf('BarGraph', module)
     `
       Bar Graph.
     `,
-    () => <BarGraph onHover={action('Hover')} data={data} {...props} />
+    () => (
+      <BarGraph
+        timeFormat="%b"
+        onHover={action('Hover')}
+        data={data}
+        {...props}
+      />
+    )
   )
   .addWithInfo(
     'Grouped',

--- a/components/DataTooltip/DataTooltip.js
+++ b/components/DataTooltip/DataTooltip.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 const propTypes = {
   className: PropTypes.string,
   data: PropTypes.array,
+  direction: PropTypes.string,
   id: PropTypes.string,
   heading: PropTypes.string,
   isActive: PropTypes.bool,
@@ -12,8 +13,9 @@ const propTypes = {
 
 const defaultProps = {
   data: [100],
+  direction: 'top',
   id: 'bx--data-tooltip',
-  heading: 'Heading',
+  heading: null,
   isActive: true,
 };
 
@@ -32,10 +34,33 @@ class DataTooltip extends Component {
   renderTooltipData() {
     const { data } = this.props;
     const items = data.map(item => {
+      let divStyle;
+      if (item.color) {
+        if (data.length <= 1) {
+          divStyle = {
+            borderTop: `4px solid ${item.color}`,
+            minHeight: '2.625rem',
+            padding: '0 0.625rem',
+          };
+        } else {
+          divStyle = {
+            borderLeft: `4px solid ${item.color}`,
+            minHeight: '2rem',
+          };
+        }
+      } else {
+        divStyle = {
+          minHeight: '1.625rem',
+          padding: '0 0.625rem',
+        };
+      }
+
       return (
-        <li className="bx--tooltip-list-item">
-          <span>{item}</span>
-          <span>Test</span>
+        <li style={divStyle} className="bx--tooltip-list-item">
+          {item.label && (
+            <span className="bx--tooltip-list-item__label">{item.label}</span>
+          )}
+          <span className="bx--tooltip-list-item__data">{item.data}</span>
         </li>
       );
     });
@@ -44,10 +69,11 @@ class DataTooltip extends Component {
   }
 
   render() {
-    const { heading, isActive, className } = this.props;
+    const { className, direction, heading, isActive } = this.props;
 
     const tooltipClasses = classNames(
       'bx--tooltip',
+      'bx--data-tooltip',
       {
         'bx--tooltip--shown': isActive,
       },
@@ -55,8 +81,8 @@ class DataTooltip extends Component {
     );
 
     return (
-      <div className={tooltipClasses} data-floating-menu-direction="right">
-        <p className="bx--tooltip__label">{heading}</p>
+      <div className={tooltipClasses} data-floating-menu-direction={direction}>
+        {heading && <p className="bx--tooltip__label">{heading}</p>}
         <ul className="bx--tooltip-list">{this.renderTooltipData()}</ul>
       </div>
     );

--- a/components/DataTooltip/DataTooltip.js
+++ b/components/DataTooltip/DataTooltip.js
@@ -20,17 +20,6 @@ const defaultProps = {
 };
 
 class DataTooltip extends Component {
-  componentDidMount() {}
-
-  // shouldComponentUpdate(nextProps) {
-  //   return this.props.isActive !== nextProps.isActive;
-  // }
-
-  componentWillReceiveProps() {}
-
-  // shouldComponentUpdate(nextProps) {}
-  componentWillUpdate() {}
-
   renderTooltipData() {
     const { data } = this.props;
     const items = data.map((item, i) => {
@@ -47,14 +36,19 @@ class DataTooltip extends Component {
             margin: `.5rem 1rem`,
             borderLeft: `4px solid ${item.color}`,
             minHeight: '2rem',
-            paddingLeft: '1rem',
+            paddingLeft: '.5rem',
           };
-          // if (data.length >= 4) {
-          //   divStyle.maxWidth = 'calc(50% - 2rem)';
-          // }
 
           if (i === data.length - 1) {
             divStyle.marginBottom = '1rem';
+          }
+
+          if (data.length > 3 && i >= data.length / 2) {
+            divStyle.marginLeft = '0';
+          }
+
+          if (data.length > 3 && i < data.length / 2) {
+            divStyle.marginRight = '0';
           }
         }
       } else {
@@ -78,7 +72,14 @@ class DataTooltip extends Component {
   }
 
   render() {
-    const { className, direction, heading, isActive } = this.props;
+    const {
+      className,
+      direction,
+      heading,
+      isActive,
+      data,
+      ...other
+    } = this.props;
 
     const tooltipClasses = classNames(
       'bx--tooltip',
@@ -89,10 +90,20 @@ class DataTooltip extends Component {
       className
     );
 
+    const listStyle = {
+      columnCount: data.length > 3 ? '2' : '1',
+      columnGap: '1.25rem',
+    };
+
     return (
-      <div className={tooltipClasses} data-floating-menu-direction={direction}>
+      <div
+        className={tooltipClasses}
+        data-floating-menu-direction={direction}
+        {...other}>
         {heading && <p className="bx--tooltip__label">{heading}</p>}
-        <ul className="bx--tooltip-list">{this.renderTooltipData()}</ul>
+        <ul className="bx--tooltip-list" style={listStyle}>
+          {this.renderTooltipData()}
+        </ul>
       </div>
     );
   }

--- a/components/DataTooltip/DataTooltip.js
+++ b/components/DataTooltip/DataTooltip.js
@@ -1,0 +1,69 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import classNames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string,
+  data: PropTypes.array,
+  id: PropTypes.string,
+  heading: PropTypes.string,
+  isActive: PropTypes.bool,
+};
+
+const defaultProps = {
+  data: [100],
+  id: 'bx--data-tooltip',
+  heading: 'Heading',
+  isActive: true,
+};
+
+class DataTooltip extends Component {
+  componentDidMount() {}
+
+  // shouldComponentUpdate(nextProps) {
+  //   return this.props.isActive !== nextProps.isActive;
+  // }
+
+  componentWillReceiveProps() {}
+
+  // shouldComponentUpdate(nextProps) {}
+  componentWillUpdate() {}
+
+  renderTooltipData() {
+    const { data } = this.props;
+    const items = data.map(item => {
+      return (
+        <li className="bx--tooltip-list-item">
+          <span>{item}</span>
+          <span>Test</span>
+        </li>
+      );
+    });
+
+    return items;
+  }
+
+  render() {
+    const { heading, isActive, className } = this.props;
+
+    const tooltipClasses = classNames(
+      'bx--tooltip',
+      {
+        'bx--tooltip--shown': isActive,
+      },
+      className
+    );
+
+    return (
+      <div className={tooltipClasses} data-floating-menu-direction="right">
+        <p className="bx--tooltip__label">{heading}</p>
+        <ul className="bx--tooltip-list">{this.renderTooltipData()}</ul>
+      </div>
+    );
+  }
+}
+
+DataTooltip.propTypes = propTypes;
+DataTooltip.defaultProps = defaultProps;
+
+export default DataTooltip;

--- a/components/DataTooltip/DataTooltip.js
+++ b/components/DataTooltip/DataTooltip.js
@@ -33,7 +33,7 @@ class DataTooltip extends Component {
 
   renderTooltipData() {
     const { data } = this.props;
-    const items = data.map(item => {
+    const items = data.map((item, i) => {
       let divStyle;
       if (item.color) {
         if (data.length <= 1) {
@@ -44,9 +44,18 @@ class DataTooltip extends Component {
           };
         } else {
           divStyle = {
+            margin: `.5rem 1rem`,
             borderLeft: `4px solid ${item.color}`,
             minHeight: '2rem',
+            paddingLeft: '1rem',
           };
+          // if (data.length >= 4) {
+          //   divStyle.maxWidth = 'calc(50% - 2rem)';
+          // }
+
+          if (i === data.length - 1) {
+            divStyle.marginBottom = '1rem';
+          }
         }
       } else {
         divStyle = {
@@ -56,7 +65,7 @@ class DataTooltip extends Component {
       }
 
       return (
-        <li style={divStyle} className="bx--tooltip-list-item">
+        <li key={i} style={divStyle} className="bx--tooltip-list-item">
           {item.label && (
             <span className="bx--tooltip-list-item__label">{item.label}</span>
           )}

--- a/components/DataTooltip/DataTooltip.story.js
+++ b/components/DataTooltip/DataTooltip.story.js
@@ -29,7 +29,7 @@ const maxData = [
 ];
 
 const props = {
-  heading: 'January',
+  heading: 'Label 2',
 };
 
 storiesOf('DataTooltip', module)

--- a/components/DataTooltip/DataTooltip.story.js
+++ b/components/DataTooltip/DataTooltip.story.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import DataTooltip from './DataTooltip';
+
+storiesOf('DataTooltip', module).addWithInfo(
+  'Default',
+  `
+      Data Tooltip.
+    `,
+  () => <DataTooltip />
+);

--- a/components/DataTooltip/DataTooltip.story.js
+++ b/components/DataTooltip/DataTooltip.story.js
@@ -30,6 +30,8 @@ const maxData = [
 
 const props = {
   heading: 'Label 2',
+  direction: 'bottom',
+  isActive: true,
 };
 
 storiesOf('DataTooltip', module)

--- a/components/DataTooltip/DataTooltip.story.js
+++ b/components/DataTooltip/DataTooltip.story.js
@@ -2,10 +2,69 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import DataTooltip from './DataTooltip';
 
-storiesOf('DataTooltip', module).addWithInfo(
-  'Default',
-  `
+const singleNoColorData = [{ data: '$250.17' }];
+
+const singleData = [{ data: '$250.17', label: 'Jan', color: '#3b1a40' }];
+
+const tripleData = [
+  { data: '$123.45', label: 'Jan', color: '#3b1a40' },
+  { data: '$112.22', label: 'Feb', color: '#473793' },
+  { data: '$250.17', label: 'Mar', color: '#3c6df0' },
+];
+
+const quadData = [
+  { data: '$123.45', label: 'Jan', color: '#3b1a40' },
+  { data: '$112.22', label: 'Feb', color: '#473793' },
+  { data: '$250.17', label: 'Mar', color: '#3c6df0' },
+  { data: '$123.45', label: 'Apr', color: '#00a68f' },
+];
+
+const maxData = [
+  { data: '$123.45', label: 'Jan', color: '#3b1a40' },
+  { data: '$112.22', label: 'Feb', color: '#473793' },
+  { data: '$250.17', label: 'Mar', color: '#3c6df0' },
+  { data: '$123.45', label: 'Apr', color: '#00a68f' },
+  { data: '$112.22', label: 'May', color: '#48d4bb' },
+  { data: '$250.17', label: 'Jun', color: '#9b82f3' },
+];
+
+const props = {
+  heading: 'January',
+};
+
+storiesOf('DataTooltip', module)
+  .addWithInfo(
+    'Default',
+    `
+    Data Tooltip.
+  `,
+    () => <DataTooltip data={singleNoColorData} />
+  )
+  .addWithInfo(
+    'Single',
+    `
       Data Tooltip.
     `,
-  () => <DataTooltip />
-);
+    () => <DataTooltip data={singleData} />
+  )
+  .addWithInfo(
+    'Triple',
+    `
+      Data Tooltip.
+    `,
+    () => <DataTooltip data={tripleData} {...props} />
+  )
+  .addWithInfo(
+    'Quad',
+    `
+      Data Tooltip.
+    `,
+    () => <DataTooltip data={quadData} {...props} />
+  )
+  .addWithInfo(
+    'Max',
+    `
+      Data Tooltip.
+    `,
+    () => <DataTooltip data={maxData} {...props} />
+  );

--- a/components/DataTooltip/_data-tooltip.scss
+++ b/components/DataTooltip/_data-tooltip.scss
@@ -1,0 +1,31 @@
+.bx--data-tooltip {
+  padding: 0;
+}
+
+.bx--tooltip-list-item {
+  display: inline-flex;
+  align-items: flex-start;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.bx--tooltip-list-item__data {
+  background-color: $ui-01;
+  z-index: 2;
+}
+
+.bx--tooltip-list-item__label {
+  color: $text-02;
+  font-size: rem(12px);
+}
+
+.bx--tooltip-list-item--single {
+}
+
+.bx--tooltip-list-item--multiple {
+}
+
+.bx--tooltip-list-item--no-color {
+  height: 1.625rem;
+  padding: 0 0.625rem;
+}

--- a/components/DataTooltip/_data-tooltip.scss
+++ b/components/DataTooltip/_data-tooltip.scss
@@ -1,31 +1,56 @@
 .bx--data-tooltip {
   padding: 0;
+  max-width: 1000rem;
+  display: flex;
+  flex-direction: column;
 }
 
-.bx--tooltip-list-item {
+.bx--data-tooltip .bx--tooltip__label {
+  width: 100%;
+  height: rem(32px);
+  display: inline-flex;
+  align-items: center;
+  font-size: rem(14px);
+  color: $text-02;
+  padding: 0 1rem;
+  white-space: nowrap;
+  border-bottom: 1px solid $ui-04;
+}
+
+.bx--data-tooltip .bx--tooltip-list {
+  display: flex;
+  flex-wrap: wrap;
+  width: auto;
+}
+
+.bx--data-tooltip .bx--tooltip-list-item {
   display: inline-flex;
   align-items: flex-start;
   justify-content: center;
   flex-direction: column;
 }
 
-.bx--tooltip-list-item__data {
+.test {
+  width: 100%;
+  display: block;
+}
+
+.bx--data-tooltip .bx--tooltip-list-item__data {
   background-color: $ui-01;
   z-index: 2;
 }
 
-.bx--tooltip-list-item__label {
+.bx--data-tooltip .bx--tooltip-list-item__label {
   color: $text-02;
   font-size: rem(12px);
 }
 
-.bx--tooltip-list-item--single {
+.bx--data-tooltip .bx--tooltip-list-item__data,
+.bx--data-tooltip .bx--tooltip-list-item__label {
+  display: inline-block;
 }
 
-.bx--tooltip-list-item--multiple {
-}
-
-.bx--tooltip-list-item--no-color {
+.bx--data-tooltip .bx--tooltip-list-item--no-color {
   height: 1.625rem;
   padding: 0 0.625rem;
 }

--- a/components/DataTooltip/_data-tooltip.scss
+++ b/components/DataTooltip/_data-tooltip.scss
@@ -1,8 +1,5 @@
 .bx--data-tooltip {
   padding: 0;
-  max-width: 1000rem;
-  display: flex;
-  flex-direction: column;
 }
 
 .bx--data-tooltip .bx--tooltip__label {
@@ -17,12 +14,6 @@
   border-bottom: 1px solid $ui-04;
 }
 
-.bx--data-tooltip .bx--tooltip-list {
-  display: flex;
-  flex-wrap: wrap;
-  width: auto;
-}
-
 .bx--data-tooltip .bx--tooltip-list-item {
   display: inline-flex;
   align-items: flex-start;
@@ -30,12 +21,8 @@
   flex-direction: column;
 }
 
-.test {
-  width: 100%;
-  display: block;
-}
-
 .bx--data-tooltip .bx--tooltip-list-item__data {
+  font-weight: 600;
   background-color: $ui-01;
   z-index: 2;
 }

--- a/index.scss
+++ b/index.scss
@@ -1,1 +1,1 @@
-
+@import 'components/DataTooltip/data-tooltip';


### PR DESCRIPTION
## Data Tooltip

### Props
- `data` -  ex: `[{ data: '$250.17', label: 'Jan', color: '#3b1a40' }]`
- `heading`
- `direction`
- `isActive` 



### Single, no color
![screen shot 2018-02-07 at 9 45 15 am](https://user-images.githubusercontent.com/11928039/35925716-108be560-0bec-11e8-939f-0b86631fd98a.png)

### Single, with label
![screen shot 2018-02-07 at 9 45 23 am](https://user-images.githubusercontent.com/11928039/35925720-13ed9c94-0bec-11e8-940b-2352fe3c59a4.png)

### 3 items
![screen shot 2018-02-07 at 9 45 29 am](https://user-images.githubusercontent.com/11928039/35925734-187e9ccc-0bec-11e8-9993-d1c1504ec842.png)

### 4 items
![screen shot 2018-02-07 at 9 45 37 am](https://user-images.githubusercontent.com/11928039/35925737-1b7c2e30-0bec-11e8-83b4-2a30c6dcb4b9.png)

### Max items
![screen shot 2018-02-07 at 9 45 49 am](https://user-images.githubusercontent.com/11928039/35925740-1e3277ec-0bec-11e8-85ae-535439f75475.png)
#