### PR TITLE
fix(data-tooltip): move styles from inline to classes

### DIFF
--- a/components/DataTooltip/DataTooltip.js
+++ b/components/DataTooltip/DataTooltip.js
@@ -28,42 +28,47 @@ class DataTooltip extends Component {
         if (data.length <= 1) {
           divStyle = {
             borderTop: `4px solid ${item.color}`,
-            minHeight: '2.625rem',
-            padding: '0 0.625rem',
           };
         } else {
           divStyle = {
-            margin: `.5rem 1rem`,
             borderLeft: `4px solid ${item.color}`,
-            minHeight: '2rem',
-            paddingLeft: '.5rem',
           };
-
-          if (i === data.length - 1) {
-            divStyle.marginBottom = '1rem';
-          }
-
-          if (data.length > 3 && i >= data.length / 2) {
-            divStyle.marginLeft = '0';
-          }
-
-          if (data.length > 3 && i < data.length / 2) {
-            divStyle.marginRight = '0';
-          }
         }
-      } else {
-        divStyle = {
-          minHeight: '1.625rem',
-          padding: '0 0.625rem',
-        };
       }
 
+      const tooltipItemClasses = classNames(
+        'bx--data-tooltip-list-item',
+        {
+          'bx--data-tooltip__base': !item.color && data.length <= 1,
+        },
+        {
+          'bx--data-tooltip__single': item.color && data.length <= 1,
+        },
+        {
+          'bx--data-tooltip__multiple': item.color && data.length > 1,
+        },
+        {
+          'bx--data-tooltip__multiple--last':
+            item.color && data.length > 1 && i === data.length - 1,
+        },
+        {
+          'bx--data-tooltip__multiple--right':
+            item.color && (data.length > 3 && i >= data.length / 2),
+        },
+        {
+          'bx--data-tooltip__multiple--left':
+            item.color && (data.length > 3 && i < data.length / 2),
+        }
+      );
+
       return (
-        <li key={i} style={divStyle} className="bx--tooltip-list-item">
+        <li key={i} style={divStyle} className={tooltipItemClasses}>
           {item.label && (
-            <span className="bx--tooltip-list-item__label">{item.label}</span>
+            <span className="bx--data-tooltip-list-item__label">
+              {item.label}
+            </span>
           )}
-          <span className="bx--tooltip-list-item__data">{item.data}</span>
+          <span className="bx--data-tooltip-list-item__data">{item.data}</span>
         </li>
       );
     });
@@ -100,8 +105,8 @@ class DataTooltip extends Component {
         className={tooltipClasses}
         data-floating-menu-direction={direction}
         {...other}>
-        {heading && <p className="bx--tooltip__label">{heading}</p>}
-        <ul className="bx--tooltip-list" style={listStyle}>
+        {heading && <p className="bx--data-tooltip__label">{heading}</p>}
+        <ul className="bx--data-tooltip-list" style={listStyle}>
           {this.renderTooltipData()}
         </ul>
       </div>

--- a/components/DataTooltip/_data-tooltip.scss
+++ b/components/DataTooltip/_data-tooltip.scss
@@ -2,7 +2,7 @@
   padding: 0;
 }
 
-.bx--data-tooltip .bx--tooltip__label {
+.bx--data-tooltip__label {
   width: 100%;
   height: rem(32px);
   display: inline-flex;
@@ -14,30 +14,53 @@
   border-bottom: 1px solid $ui-04;
 }
 
-.bx--data-tooltip .bx--tooltip-list-item {
+.bx--data-tooltip-list-item {
   display: inline-flex;
   align-items: flex-start;
   justify-content: center;
   flex-direction: column;
 }
 
-.bx--data-tooltip .bx--tooltip-list-item__data {
+.bx--data-tooltip-list-item__data {
   font-weight: 600;
   background-color: $ui-01;
   z-index: 2;
 }
 
-.bx--data-tooltip .bx--tooltip-list-item__label {
+.bx--data-tooltip-list-item__label {
   color: $text-02;
   font-size: rem(12px);
 }
 
-.bx--data-tooltip .bx--tooltip-list-item__data,
-.bx--data-tooltip .bx--tooltip-list-item__label {
+.bx--data-tooltip-list-item__data,
+.bx--data-tooltip-list-item__label {
   display: inline-block;
 }
 
-.bx--data-tooltip .bx--tooltip-list-item--no-color {
-  height: 1.625rem;
+.bx--data-tooltip__base {
+  min-height: 1.625rem;
   padding: 0 0.625rem;
+}
+
+.bx--data-tooltip__single {
+  min-height: 2.625rem;
+  padding: 0 0.625rem;
+}
+
+.bx--data-tooltip__multiple {
+  margin: 0.5rem 1rem;
+  min-height: 2rem;
+  padding-left: 0.5rem;
+}
+
+.bx--data-tooltip__multiple--last {
+  margin-bottom: 1rem;
+}
+
+.bx--data-tooltip__multiple--right {
+  margin-left: 0;
+}
+
+.bx--data-tooltip__multiple--left {
+  margin-right: 0;
 }


### PR DESCRIPTION
### Cleaned up classes
- Classes are now all under the `bx--data-tooltip` umbrella

### Move styles
- Classes moved from inline styles to custom css classes
-- `.bx--data-tooltip__base`
-- `.bx--data-tooltip__single`
-- `.bx--data-tooltip__multiple`
-- `.bx--data-tooltip__multiple--last`
-- `.bx--data-tooltip__multiple--right`
-- `.bx--data-tooltip__multiple--left`