### PR TITLE
docs(readme): add documentation around importing styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Import the graph:
 
 `import { LineGraph } from 'carbon-addons-data-viz-react';`
 
+Import the styles: 
+
+`@import 'carbon-components-data-viz-react/scss/index'`
+
 Here is a link to a Code Sandbox example in which you can play around: https://codesandbox.io/s/ov4169pq36
 
 ## Current Components


### PR DESCRIPTION
Adds in documentation on how to import styles for `DataTooltip` and future data viz components that rely on css