### PR TITLE
Add tooltips to LineGraph and BarGraph

### DIFF
--- a/components/BarGraph/BarGraph.story.js
+++ b/components/BarGraph/BarGraph.story.js
@@ -159,6 +159,13 @@ storiesOf('BarGraph', module)
         onHover={action('Hover')}
         data={groupedData}
         {...props}
+        seriesLabels={[
+          'Series 1',
+          'Series 2',
+          'Series 3',
+          'Series 4',
+          'Series 5',
+        ]}
       />
     )
   )

--- a/components/LineGraph/LineGraph.story.js
+++ b/components/LineGraph/LineGraph.story.js
@@ -70,6 +70,7 @@ class LineGraphContainer extends Component {
       id: this.props.id,
       containerId: this.props.containerId,
       drawLine: this.props.drawLine,
+      seriesLabels: ['Series 1', 'Series 2', 'Series 3'],
     };
 
     return <LineGraph {...props} />;
@@ -147,6 +148,7 @@ storiesOf('LineGraph', module)
       onHover={action('Hover')}
       onMouseOut={action('Mouseout')}
       onBlur={action('Blur')}
+      seriesLabels={['Series 1', 'Series 2', 'Series 3']}
       isXTime={false}
     />
   ))


### PR DESCRIPTION
**LineGraph** -- hover mouse anywhere on graph, show tooltip for nearest data point/s
- if multiple series with same x values, shows one tooltip with all y values for nearest x value
![screen shot 2018-03-01 at 4 40 26 pm](https://user-images.githubusercontent.com/35227304/36871201-73bcdf1a-1d6f-11e8-8171-04ff8c43e22c.png)
- if multiple series with different x values, shows tooltip with x and y for nearest point
![screen shot 2018-03-01 at 4 40 36 pm](https://user-images.githubusercontent.com/35227304/36871188-63570916-1d6f-11e8-8079-8eccb82983c1.png)

**BarGraph** -- when hovering over bar, show tooltip for that bar
![screen shot 2018-03-01 at 4 40 00 pm](https://user-images.githubusercontent.com/35227304/36871208-7837c2e4-1d6f-11e8-9576-c8fa0103522d.png)
