### PR TITLE
fix(line-graph): adding extra null checks

### DIFF
--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -486,11 +486,15 @@ class LineGraph extends Component {
       _.max(this.props.datasets.map(d => d.length)) > 2
     ) {
       this.props.onMouseOut();
-      ReactDOM.unmountComponentAtNode(this.tooltipId);
+      if (this.tooltipId) {
+        ReactDOM.unmountComponentAtNode(this.tooltipId);
+      }
     }
   }
 
   onMouseMove() {
+    if (!this.id) return null;
+
     const {
       margin,
       data,


### PR DESCRIPTION
This PR adds 2 null checks:
1. Check if `tooltipId` exists before trying to unmount it
2. Check if `id` exists before trying to use it in `onMouseMove` for `d3.mouse(this.id)`