### PR TITLE
fix: isUTC does NOT Display UTC Times in X Axis

### DIFF
--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -313,11 +313,15 @@ class LineGraph extends Component {
       .y(d => this.y(d[this.count]))
       .defined(d => !isNaN(d[this.count]));
 
+    const tickFormat = isUTC
+      ? d3.utcFormat(timeFormat)
+      : d3.timeFormat(timeFormat);
+
     this.xAxis = d3
       .axisBottom()
       .scale(this.x)
       .tickSize(0)
-      .tickFormat(isXTime ? d3.timeFormat(timeFormat) : null);
+      .tickFormat(isXTime ? tickFormat : null);
 
     this.yAxis = d3
       .axisLeft()


### PR DESCRIPTION
## Current Behavior
The `LineGraph.js` component currently will not display times in the x-axis according to *UTC* even with `isUTC: true`. 

## Desired Behavior
When you enter `isUTC: true` as a prop, the Line Graph will display all date values (ie. 1528487686098) for UTC time (as seen from time zone +00 or Greenwich Mean Time).

## The fix
The bug happens because `d3.timeFormat` defaults to locale time. If we use `d3.utcFormat` it will use UTC time. 

Docs for [d3.timeFomat](https://github.com/d3/d3-time-format/blob/master/README.md#timeFormat).

Docs for [d3.utcFormat](https://github.com/d3/d3-time-format/blob/master/README.md#utcFormat).
> Equivalent to locale.format, except all directives are interpreted as Coordinated Universal Time (UTC) rather than local time.
