### PR TITLE
fix(linegraph): add localized date-time for x-axis

### DIFF
--- a/components/LineGraph/LineGraph.js
+++ b/components/LineGraph/LineGraph.js
@@ -20,6 +20,16 @@ const propTypes = {
    * If your data set has multiple series, the seriesLabels array should contain strings labeling your series in the same order that your series appear in either data or datasets props.
    */
   seriesLabels: PropTypes.arrayOf(PropTypes.string),
+  timeFormatLocale: PropTypes.shape({
+    dateTime: PropTypes.string,
+    date: PropTypes.string,
+    time: PropTypes.string,
+    periods: PropTypes.arrayOf(PropTypes.string),
+    days: PropTypes.arrayOf(PropTypes.string),
+    shortDays: PropTypes.arrayOf(PropTypes.string),
+    months: PropTypes.arrayOf(PropTypes.string),
+    shortMonths: PropTypes.arrayOf(PropTypes.string),
+  }),
   height: PropTypes.number,
   width: PropTypes.number,
   id: PropTypes.string,
@@ -276,6 +286,7 @@ class LineGraph extends Component {
       isXTime,
       showLegend,
       seriesLabels,
+      timeFormatLocale,
     } = this.props;
 
     this.updateEmptyState(data.length > 0 ? data : datasets);
@@ -312,6 +323,10 @@ class LineGraph extends Component {
       .x(d => this.x(d[d.length - 1]))
       .y(d => this.y(d[this.count]))
       .defined(d => !isNaN(d[this.count]));
+
+    if (timeFormatLocale) {
+      d3.timeFormatDefaultLocale(timeFormatLocale);
+    }
 
     const tickFormat = isUTC
       ? d3.utcFormat(timeFormat)
@@ -464,7 +479,7 @@ class LineGraph extends Component {
       .attr('class', 'legend')
       .attr('transform', (d, i) => {
         const h = legendRectSize + legendSpacing;
-        const offset = h * seriesLabels.length / 2;
+        const offset = (h * seriesLabels.length) / 2;
         const horz = this.width + 10;
         const vert = i * h - offset + 50;
         return `translate(${horz},${vert})`;
@@ -599,8 +614,7 @@ class LineGraph extends Component {
           .node()
           .getBoundingClientRect();
         const offset = -tooltipSize.width / 2;
-        d3
-          .select(this.tooltipId)
+        d3.select(this.tooltipId)
           .style('position', 'relative')
           .style('left', `${mouseData.graphX + labelOffsetX + offset}px`)
           .style(


### PR DESCRIPTION
## Language Localization!
`D3` allows users to format the date-time in the x-axis of our LineGraph, but also to _Localize_ that data with the region of our choice. We can add French and get French month names, and days of the week, or Russian, or whatever. This PR allows us to do that with LineGraph.

## More control over all formatting
As you can see in the [D3 docs](https://github.com/d3/d3-time-format#locales), this gives you control over every part of the date and time formatting on a very granular level.

## Where can you get all that formatting data?
In [this example](https://bl.ocks.org/mbostock/6f1cc065d4d172bcaf322e399aa8d62f) we see they use an api call to `https://unpkg.com/d3-time-format@2/locale/ru-RU.json` for the Russian formatting. notice in the url `ru-RU`. You can get your locale from your browser with `navigator.language` to get your user's locale, then substitute that string in the URL. For example, for French, click on [https://unpkg.com/d3-time-format@2/locale/fr-FR.json](https://unpkg.com/d3-time-format@2/locale/fr-FR.json), for Great Britain: [https://unpkg.com/d3-time-format@2/locale/en-GB.json](https://unpkg.com/d3-time-format@2/locale/en-GB.json).

### Example with French Localization

![screen shot 2018-06-13 at 7 13 57 pm](https://user-images.githubusercontent.com/1697656/41384896-13754202-6f3e-11e8-8deb-d2eb6b97b4de.png)

[Here are the D3 docs](https://github.com/d3/d3-time-format#locales) talking about this feature.

[Here is an example](https://bl.ocks.org/mbostock/805115ebaa574e771db1875a6d828949) of this method in use.

