### PR TITLE
feat(bargraph): add optional maxValueY prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Pie charts show individual values that make up a whole data set so users can com
 | emptyText    | string | There is currently no data available                    |
 | onHover      | func   | () => {}                                                |
 | color        | array  | ['#00a68f', '#3b1a40', '#473793', '#3c6df0', '#56D2BB'] |
+| maxValueY    | number | 1500                                                    |
 
 ### Line Graph
 

--- a/components/BarGraph/BarGraph.js
+++ b/components/BarGraph/BarGraph.js
@@ -23,6 +23,7 @@ const propTypes = {
   emptyText: PropTypes.string,
   color: PropTypes.array,
   showTooltip: PropTypes.bool,
+  maxValueY: PropTypes.number,
 };
 
 const defaultProps = {
@@ -89,6 +90,7 @@ class BarGraph extends Component {
   }
 
   componentWillUpdate(nextProps) {
+    const { maxValueY } = this.props;
     if (this.x) {
       this.x.domain(nextProps.data.map(d => d[1]));
 
@@ -97,9 +99,12 @@ class BarGraph extends Component {
         this.x1
           .rangeRound([0, this.x.bandwidth()])
           .domain(d3.range(dataLength));
-        this.y.domain([0, d3.max(nextProps.data, d => d3.max(d[0], i => i))]);
+        this.y.domain([
+          0,
+          maxValueY || d3.max(nextProps.data, d => d3.max(d[0], i => i)),
+        ]);
       } else {
-        this.y.domain([0, d3.max(nextProps.data, d => d[0])]);
+        this.y.domain([0, maxValueY || d3.max(nextProps.data, d => d[0])]);
       }
 
       this.updateEmptyState(nextProps.data);
@@ -112,7 +117,7 @@ class BarGraph extends Component {
   }
 
   initialRender() {
-    const { data, timeFormat } = this.props;
+    const { data, timeFormat, maxValueY } = this.props;
 
     this.updateEmptyState(data);
 
@@ -135,12 +140,12 @@ class BarGraph extends Component {
       this.y = d3
         .scaleLinear()
         .range([this.height, 0])
-        .domain([0, d3.max(data, d => d3.max(d[0], i => i))]);
+        .domain([0, maxValueY || d3.max(data, d => d3.max(d[0], i => i))]);
     } else {
       this.y = d3
         .scaleLinear()
         .range([this.height, 0])
-        .domain([0, d3.max(data, d => d[0])]);
+        .domain([0, maxValueY || d3.max(data, d => d[0])]);
     }
 
     this.xAxis = d3
@@ -379,9 +384,8 @@ class BarGraph extends Component {
     rect
       .transition()
       .duration(500)
-      .attr(
-        'fill',
-        () => (this.isGrouped ? this.color(mouseData.index) : this.color(0))
+      .attr('fill', () =>
+        this.isGrouped ? this.color(mouseData.index) : this.color(0)
       );
     ReactDOM.unmountComponentAtNode(this.tooltipId);
   }

--- a/components/BarGraph/BarGraph.story.js
+++ b/components/BarGraph/BarGraph.story.js
@@ -65,6 +65,7 @@ class UpdatingBarGraphContainer extends Component {
       id: this.props.id,
       containerId: this.props.containerId,
       drawLine: this.props.drawLine,
+      maxValueY: this.props.maxValueY,
     };
 
     return <BarGraph data={data} {...props} />;
@@ -182,4 +183,16 @@ storiesOf('BarGraph', module)
      Empty Bar Graph.
     `,
     () => <BarGraph onHover={action('Hover')} data={singleData} {...props} />
-  );
+  )
+  .addWithInfo('With Max Y Value', () => (
+    <BarGraph
+      timeFormat="%b"
+      onHover={action('Hover')}
+      data={data}
+      maxValueY={1500}
+      {...props}
+    />
+  ))
+  .addWithInfo('With Max Y Value and Updating', () => (
+    <UpdatingBarGraphContainer maxValueY={1500} />
+  ));


### PR DESCRIPTION
We're currently facing a situation where we have 2 bar graphs near eachother, each with different data sets. See below: 

![Screen Shot 2019-04-03 at 2 53 53 PM](https://user-images.githubusercontent.com/8573243/55510388-d2ae6780-5623-11e9-8513-1d732f3317f3.png)

Unfortunately since each chart is sized according to its maximum value in the dataset, the charts look like they are showing the same values (on first glance) when in fact the columns differ by a factor of 10. (see the Y scale on each - 300 vs 3000) Basically the visual proportions are all wrong.

It would be really useful if we could optionally define a "max Y value" on the bar graph so that, in this case, we could relate the visual proportion of one chart to another. 

This PR adds that functionality by allowing an optional prop called `maxValueY` which will take precedence over the current y-domain calculation (but will defer to the previous calculation when it's absent.) I've also added a couple of storybook examples to show the constraint in action, both with a static chart and a dynamically updating one.

With the new prop you can achieve something like this: 
![Screen Shot 2019-04-03 at 3 26 12 PM](https://user-images.githubusercontent.com/8573243/55510872-db536d80-5624-11e9-9720-2d1b83a474f0.png)
Where the user gets to define the vertical scale and proportionality, instead of d3 calculating the max automatically.